### PR TITLE
fix(client): Fix ssl parameter when constructing RabbitMQConfig

### DIFF
--- a/rabbitmq_rpc/client.py
+++ b/rabbitmq_rpc/client.py
@@ -66,7 +66,7 @@ class RPCClient:
                 password=password,
                 vhost=vhost,
                 url=url,
-                ssl_connection=ssl,
+                ssl=ssl,
             )
 
         url = config.get_url()

--- a/rabbitmq_rpc/config.py
+++ b/rabbitmq_rpc/config.py
@@ -3,7 +3,7 @@ from typing import Optional, TypeVar
 
 from aio_pika.connection import make_url
 from decouple import config
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 T = TypeVar('T')
 
@@ -15,6 +15,7 @@ def env_var(field_name: str, default = None, cast_type = str) -> T:
         return default
 
 class RabbitMQConfig(BaseModel):
+    model_config = ConfigDict(extra='forbid')
     host: Optional[str] = Field(default_factory=lambda: env_var("RABBITMQ_HOST", "localhost", str))
     port: Optional[int] = Field(default_factory=lambda: env_var("RABBITMQ_PORT", 5672, int))
     user: Optional[str] = Field(default_factory=lambda: env_var("RABBITMQ_USER", "rabbitmq_user", str))


### PR DESCRIPTION
Without this changeset the ssl parameter is not properly used. This results in connection attempts using amqp:// to amqps:// endpoints.